### PR TITLE
Update password reveal mechanism

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
         }
         #secret {
             margin-top: 2rem;
+            display: none;
         }
         #infoContent, #calendarContent {
             display: none;
@@ -95,6 +96,18 @@
                 alert("Incorrect password. Please try again.");
             }
         }
+
+        var secretShown = false;
+        var doubleClicked = false;
+        document.addEventListener("dblclick", function(e) {
+            if (e.button === 0) doubleClicked = true;
+        });
+        document.addEventListener("keydown", function(e) {
+            if (!secretShown && doubleClicked && (e.key === "v" || e.key === "V")) {
+                document.getElementById("secret").style.display = "block";
+                secretShown = true;
+            }
+        });
 
         // Show default tab
         showTab('info');


### PR DESCRIPTION
## Summary
- hide the password entry section by default
- allow double-click + `V` key press to reveal password field

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6847ba0b6edc8323851f096a7b1ebd90